### PR TITLE
Feat - 사용자 입고 신청 내역 구현

### DIFF
--- a/src/main/java/com/ssginc/wms/incomeApply/IncomeApplyDAO.java
+++ b/src/main/java/com/ssginc/wms/incomeApply/IncomeApplyDAO.java
@@ -1,0 +1,81 @@
+package com.ssginc.wms.incomeApply;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class IncomeApplyDAO {
+    private static final String URL = "jdbc:mysql://localhost:3306/wms";
+    private static final String USER = "root";
+    private static final String PASSWORD = "1234";
+
+    // DB 연결 메서드
+    private Connection connect() throws SQLException {
+        return DriverManager.getConnection(URL, USER, PASSWORD);
+    }
+
+    // 1. 입고 신청 내역 테이블 전시 (income_apply + product 테이블 조인 데이터 조회 메서드)
+    public List<ProductIncomeApplyVO> getAllIncomeApply() {
+        String query = """
+                SELECT ia.apply_id, ia.product_id, ia.apply_time, ia.apply_status,
+                       p.product_name, pc.category_name
+                  FROM income_apply ia
+                  JOIN product p ON ia.product_id = p.product_id
+                  JOIN product_category pc ON p.category_id = pc.category_id
+                """;    // WHERE user_id = [로그인한 사용자 id]; 작성하기 구매자용 화면이므로
+        List<ProductIncomeApplyVO> incomeApplies = new ArrayList<>();
+
+        try (Connection conn = connect();
+             PreparedStatement stmt = conn.prepareStatement(query);
+             ResultSet rs = stmt.executeQuery()) {
+
+            // ResultSet 데이터를 VO로 변환
+            while (rs.next()) {
+                ProductIncomeApplyVO incomeApply = new ProductIncomeApplyVO();
+
+                // ResultSet 데이터를 VO 객체에 설정
+                incomeApply.setApplyId(rs.getInt("apply_id"));
+                incomeApply.setProductId(rs.getInt("product_id"));
+                incomeApply.setApplyTime(rs.getTimestamp("apply_time").toLocalDateTime());
+                String status = rs.getString("apply_status");
+                incomeApply.setApplyStatus(ProductIncomeApplyVO.Process.valueOf(status));
+                incomeApply.setProductName(rs.getString("product_name"));
+                incomeApply.setCategoryName(rs.getString("category_name")); // category_name 설정
+
+                incomeApplies.add(incomeApply);
+            }
+
+        } catch (SQLException e) {
+            System.err.println("DB 오류: " + e.getMessage());
+        } catch (IllegalArgumentException e) {
+            System.err.println("apply_status 매핑 오류: " + e.getMessage());
+        }
+
+        return incomeApplies;
+    }
+
+    // 2. 입고 대기 상태에서 입고 취소 기능
+    public boolean deletePendingIncomeApplies(List<Integer> applyIds) {
+        String query = """
+                DELETE ia
+                  FROM income_apply ia
+                 WHERE ia.apply_id = ? AND ia.apply_status = 'pending'
+                """;
+
+        try (Connection conn = connect();
+             PreparedStatement stmt = conn.prepareStatement(query)) {
+
+            for (int applyId : applyIds) {
+                stmt.setInt(1, applyId);
+                stmt.addBatch(); // 배치에 추가
+            }
+
+            int[] result = stmt.executeBatch(); // 일괄 실행
+            return result.length == applyIds.size();
+
+        } catch (SQLException e) {
+            System.err.println("삭제 중 오류 발생: " + e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/ssginc/wms/incomeApply/IncomeApplyDAO.java
+++ b/src/main/java/com/ssginc/wms/incomeApply/IncomeApplyDAO.java
@@ -78,4 +78,75 @@ public class IncomeApplyDAO {
             return false;
         }
     }
+
+    //3. 기간에 따라 품목 필터링 기능
+    public List<ProductIncomeApplyVO> getIncomeApplyWithinPeriod(int days) {
+        String query = """
+            SELECT ia.apply_id, ia.product_id, ia.apply_time, ia.apply_status,
+                   p.product_name, pc.category_name
+              FROM income_apply ia
+              JOIN product p ON ia.product_id = p.product_id
+              JOIN product_category pc ON p.category_id = pc.category_id
+             WHERE ia.apply_time >= NOW() - INTERVAL ? DAY
+            """;
+
+        List<ProductIncomeApplyVO> incomeApplies = new ArrayList<>();
+
+        try (Connection conn = connect();
+             PreparedStatement stmt = conn.prepareStatement(query)) {
+
+            stmt.setInt(1, days); // 필터링할 기간을 설정
+
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    ProductIncomeApplyVO incomeApply = new ProductIncomeApplyVO();
+                    incomeApply.setApplyId(rs.getInt("apply_id"));
+                    incomeApply.setProductId(rs.getInt("product_id"));
+                    incomeApply.setApplyTime(rs.getTimestamp("apply_time").toLocalDateTime());
+                    incomeApply.setApplyStatus(ProductIncomeApplyVO.Process.valueOf(rs.getString("apply_status")));
+                    incomeApply.setProductName(rs.getString("product_name"));
+                    incomeApply.setCategoryName(rs.getString("category_name"));
+                    incomeApplies.add(incomeApply);
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("DB 오류: " + e.getMessage());
+        }
+        return incomeApplies;
+    }
+
+    //4. 드롭다운으로 데이터의 종류를 컬럼별로 나누어 검색 기능 구현
+    public List<ProductIncomeApplyVO> searchIncomeApplies(String column, String searchText) {
+        String query = """
+                SELECT ia.apply_id, ia.product_id, ia.apply_time, ia.apply_status,
+                       p.product_name, pc.category_name
+                  FROM income_apply ia
+                  JOIN product p ON ia.product_id = p.product_id
+                  JOIN product_category pc ON p.category_id = pc.category_id
+                 WHERE LOWER(%s) LIKE LOWER(?)
+                """.formatted(column);  // 쿼리에서 column을 동적으로 설정
+
+        List<ProductIncomeApplyVO> incomeApplies = new ArrayList<>();
+        try (Connection conn = connect();
+             PreparedStatement stmt = conn.prepareStatement(query)) {
+
+            stmt.setString(1, "%" + searchText + "%"); // 검색어 설정
+
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    ProductIncomeApplyVO incomeApply = new ProductIncomeApplyVO();
+                    incomeApply.setApplyId(rs.getInt("apply_id"));
+                    incomeApply.setProductId(rs.getInt("product_id"));
+                    incomeApply.setApplyTime(rs.getTimestamp("apply_time").toLocalDateTime());
+                    incomeApply.setApplyStatus(ProductIncomeApplyVO.Process.valueOf(rs.getString("apply_status")));
+                    incomeApply.setProductName(rs.getString("product_name"));
+                    incomeApply.setCategoryName(rs.getString("category_name"));
+                    incomeApplies.add(incomeApply);
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("DB 오류: " + e.getMessage());
+        }
+        return incomeApplies;
+    }
 }

--- a/src/main/java/com/ssginc/wms/incomeApply/ProductIncomeApplyVO.java
+++ b/src/main/java/com/ssginc/wms/incomeApply/ProductIncomeApplyVO.java
@@ -14,6 +14,7 @@ public class ProductIncomeApplyVO {
     private int applyId;
     private int productId;
     private String productName;
+    private String categoryName;
     private String userId;
     private LocalDateTime applyTime;
     private Process applyStatus;

--- a/src/main/java/com/ssginc/wms/incomeApply/ProductIncomeApplyVO.java
+++ b/src/main/java/com/ssginc/wms/incomeApply/ProductIncomeApplyVO.java
@@ -1,0 +1,25 @@
+package com.ssginc.wms.incomeApply;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+
+@Setter
+@Getter
+@ToString
+public class ProductIncomeApplyVO {
+    private int applyId;
+    private int productId;
+    private String productName;
+    private String userId;
+    private LocalDateTime applyTime;
+    private Process applyStatus;
+
+    public enum Process {
+        pending,
+        completed
+    }
+}

--- a/src/main/java/com/ssginc/wms/incomeApply/ProductIncomeService.java
+++ b/src/main/java/com/ssginc/wms/incomeApply/ProductIncomeService.java
@@ -1,0 +1,11 @@
+package com.ssginc.wms.incomeApply;
+
+public class ProductIncomeService {
+
+    public String getApplyStatusAsString(ProductIncomeApplyVO productIncomeApplyVO) {
+        if (productIncomeApplyVO == null || productIncomeApplyVO.getApplyStatus() == null) {
+            return "UNKNOWN";
+        }
+        return productIncomeApplyVO.getApplyStatus().name();
+    }
+}

--- a/src/main/java/com/ssginc/wms/incomeApply/UserIncomeApplyHistoryUI.java
+++ b/src/main/java/com/ssginc/wms/incomeApply/UserIncomeApplyHistoryUI.java
@@ -1,0 +1,229 @@
+package com.ssginc.wms.incomeApply;
+
+import com.ssginc.wms.frame.CustomerFrame;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableModel;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class UserIncomeApplyHistoryUI extends CustomerFrame {
+    private JTable incomeTable;
+    private DefaultTableModel tableModel;
+    private final ProductIncomeService productIncomeService;
+    private IncomeApplyDAO dao;
+    private JButton yearButton, monthButton, weekButton;
+
+    public UserIncomeApplyHistoryUI() {
+        super();
+        this.productIncomeService = new ProductIncomeService();
+        this.dao = new IncomeApplyDAO();
+
+        setTitle("입고 신청 내역");
+
+        // JScrollPane 추가
+        JScrollPane scrollPane = new JScrollPane(incomeTable);
+        add(scrollPane, BorderLayout.CENTER);
+
+        // 상단 패널 (검색 필터 및 버튼)
+        JPanel centerPanel = new JPanel(new BorderLayout());
+
+        JPanel filterPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+
+        // 드롭다운 (컬럼 선택)
+        String[] columns = {"상품명", "카테고리", "신청 상태"};
+        JComboBox<String> columnComboBox = new JComboBox<>(columns);
+        filterPanel.add(columnComboBox);
+
+        // 검색어 입력 필드
+        JTextField searchField = new JTextField(15);
+        filterPanel.add(searchField);
+
+        // 검색 버튼
+        JButton searchButton = new JButton("검색");
+        filterPanel.add(searchButton);
+
+        // 새로고침 버튼
+        JButton refreshButton = new JButton("새로고침");
+        filterPanel.add(refreshButton);
+
+        // 삭제 버튼
+        JButton deleteButton = new JButton("입고 취소");
+        filterPanel.add(deleteButton);
+
+        centerPanel.add(filterPanel, BorderLayout.NORTH);
+
+
+        // 테이블 초기화 (체크박스를 추가)
+        tableModel = new DefaultTableModel(new String[]{
+                "선택", "신청 ID", "상품 ID", "상품 이름", "카테고리", "신청 시간", "상태"
+        }, 0) {
+            @Override
+            public Class<?> getColumnClass(int columnIndex) {
+                if (columnIndex == 0) {
+                    return Boolean.class;
+                }
+                return super.getColumnClass(columnIndex);
+            }
+        };
+        incomeTable = new JTable(tableModel);
+
+        JScrollPane incomeScrollPane = new JScrollPane(incomeTable);
+        centerPanel.add(incomeScrollPane, BorderLayout.CENTER);
+        add(centerPanel, BorderLayout.CENTER);
+
+
+        // 검색 버튼 이벤트
+        searchButton.addActionListener(e -> {
+            String selectedColumn = (String) columnComboBox.getSelectedItem();
+            String searchText = searchField.getText().trim().toLowerCase();
+
+            if (selectedColumn != null && !searchText.isEmpty()) {
+                String column = "";
+                // 선택된 컬럼에 맞게 DB 컬럼명 매핑
+                switch (selectedColumn) {
+                    case "상품명":
+                        column = "p.product_name";
+                        break;
+                    case "카테고리":
+                        column = "pc.category_name";
+                        break;
+                    case "신청 상태":
+                        column = "ia.apply_status";
+                        break;
+                }
+                // 검색된 데이터 로드
+                loadIncomeApplyDataWithSearch(column, searchText);
+            }
+        });
+
+        // 날짜 필터 버튼 추가
+        JPanel datePanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        yearButton = new JButton("1년");
+        monthButton = new JButton("1달");
+        weekButton = new JButton("1주");
+        datePanel.add(yearButton);
+        datePanel.add(monthButton);
+        datePanel.add(weekButton);
+        add(datePanel, BorderLayout.SOUTH);
+
+        // 새로고침 버튼 이벤트
+        refreshButton.addActionListener(e -> loadIncomeApplyData());
+
+        // 삭제 버튼 이벤트
+        deleteButton.addActionListener(e -> deleteSelectedRows());
+
+        // 날짜 버튼 이벤트
+        yearButton.addActionListener(e -> filterByDate(365)); // 1년
+        monthButton.addActionListener(e -> filterByDate(30));  // 1달
+        weekButton.addActionListener(e -> filterByDate(7));    // 1주
+
+        // 초기 데이터 로드
+        loadIncomeApplyData();
+
+        // JFrame 표시
+        setLocationRelativeTo(null);
+        setVisible(true);
+    }
+
+    // 검색된 데이터 로드
+    private void loadIncomeApplyDataWithSearch(String column, String searchText) {
+        List<ProductIncomeApplyVO> incomeApplies = dao.searchIncomeApplies(column, searchText);
+
+        // 테이블 데이터 모델 업데이트
+        tableModel.setRowCount(0);  // 기존 데이터 지우기
+        for (ProductIncomeApplyVO apply : incomeApplies) {
+            Object[] rowData = new Object[7];
+            rowData[0] = false;  // 체크박스 초기값
+            rowData[1] = apply.getApplyId();
+            rowData[2] = apply.getProductId();
+            rowData[3] = apply.getProductName();
+            rowData[4] = apply.getCategoryName();
+            rowData[5] = apply.getApplyTime();
+            rowData[6] = productIncomeService.getApplyStatusAsString(apply);  // Service를 사용해 변환
+
+            tableModel.addRow(rowData);
+        }
+    }
+
+    private void filterByDate(int days) {
+        IncomeApplyDAO dao = new IncomeApplyDAO();
+        List<com.ssginc.wms.incomeApply.ProductIncomeApplyVO> filteredData = dao.getIncomeApplyWithinPeriod(days);
+
+        // 테이블 데이터 모델 업데이트
+        tableModel.setRowCount(0);  // 기존 데이터 지우기
+        for (com.ssginc.wms.incomeApply.ProductIncomeApplyVO apply : filteredData) {
+            Object[] rowData = new Object[7];
+            rowData[0] = false;  // 체크박스 초기값
+            rowData[1] = apply.getApplyId();
+            rowData[2] = apply.getProductId();
+            rowData[3] = apply.getProductName();
+            rowData[4] = apply.getCategoryName();
+            rowData[5] = apply.getApplyTime();
+            rowData[6] = productIncomeService.getApplyStatusAsString(apply);  // Process -> String 변환
+
+            tableModel.addRow(rowData);
+        }
+    }
+
+    private void loadIncomeApplyData() {
+        List<ProductIncomeApplyVO> incomeApplies = dao.getAllIncomeApply();
+
+        // 테이블 데이터 모델 업데이트
+        tableModel.setRowCount(0);  // 기존 데이터 지우기
+        for (ProductIncomeApplyVO apply : incomeApplies) {
+            Object[] rowData = new Object[7];
+            rowData[0] = false;  // 체크박스 초기값
+            rowData[1] = apply.getApplyId();
+            rowData[2] = apply.getProductId();
+            rowData[3] = apply.getProductName();
+            rowData[4] = apply.getCategoryName();
+            rowData[5] = apply.getApplyTime();
+            rowData[6] = productIncomeService.getApplyStatusAsString(apply);  // Service를 사용해 변환
+
+            tableModel.addRow(rowData);
+        }
+    }
+
+    private void deleteSelectedRows() {
+        int[] selectedRows = incomeTable.getSelectedRows();
+        if (selectedRows.length == 0) {
+            JOptionPane.showMessageDialog(this, "취소할 항목을 선택하세요.");
+            return;
+        }
+
+        List<Integer> applyIdsToDelete = new ArrayList<>();
+        for (int row : selectedRows) {
+            boolean isSelected = (boolean) tableModel.getValueAt(row, 0); // 체크박스 값 확인
+            if (isSelected) {
+                int applyId = (int) tableModel.getValueAt(row, 1); // 신청 ID 가져오기
+                String status = (String) tableModel.getValueAt(row, 6); // 상태 가져오기
+
+                if ("completed".equals(status)) {
+                    // "completed" 상태인 경우 삭제 불가 메시지 표시
+                    JOptionPane.showMessageDialog(this, "이미 입고가 완료되었습니다. 취소할 수 없습니다.");
+                    return;
+                }
+
+                applyIdsToDelete.add(applyId);
+            }
+        }
+
+        if (applyIdsToDelete.isEmpty()) {
+            JOptionPane.showMessageDialog(this, "입고 대기 상태인 항목을 선택해주세요.");
+            return;
+        }
+
+        // DAO 호출하여 삭제 수행
+        IncomeApplyDAO dao = new IncomeApplyDAO();
+        boolean success = dao.deletePendingIncomeApplies(applyIdsToDelete);
+
+        if (success) {
+            JOptionPane.showMessageDialog(this, "선택된 항목이 취소되었습니다.");
+            loadIncomeApplyData(); // 데이터 갱신
+        } else {
+            JOptionPane.showMessageDialog(this, "취소 중 오류가 발생했습니다.");
+        }
+    }
+}


### PR DESCRIPTION
## 구현 내용
 - 입고 신청 내역을 테이블로 표시하는 UI 구현
 - 상품명, 카테고리, 신청 상태에 대한 검색 기능 추가
 - 날짜 필터 (1년, 1달, 1주) 기능 추가
 - 선택된 항목의 입고 취소 기능 추가
 - 입고 상태가 "completed"인 항목은 취소 불가
 - 데이터 갱신 및 UI 업데이트
 - applyStatus가 ENUM타입이므로 해당 타입을 String으로 바꾸는 작업을 하는 ProductIncomeService 클래스 구현

## 주요 메서드
 - getAllIncomeApply(): 입고 신청 내역 테이블을 전시하는 메서드
 - deletePendingIncomeApplies(): 입고 대기 상태에서 입고를 취소 시킬 수 있는 메서드
 - getIncomeApplyWithinPeriod(): 기간에 따라 품목 필터링을 하는 메서드
 - searchIncomeApplies(): 드롭 다운으로 데이터의 종류를 컬럼별로 나누어 검색 할 수 있는 메서드

## 결과 예시
![image2](https://github.com/user-attachments/assets/a64901b8-5d6e-431c-8082-b5de8ee943fc)
