### PR TITLE
Feat - 관리자 입고신청 관리 기능 구현

### DIFF
--- a/src/main/java/com/ssginc/wms/supply/AdminIncomeApplyUI.java
+++ b/src/main/java/com/ssginc/wms/supply/AdminIncomeApplyUI.java
@@ -1,0 +1,294 @@
+package com.ssginc.wms.supply;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableModel;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class AdminIncomeApplyUI extends JFrame {
+    private JTable applicationTable;
+    private JComboBox<String> categoryComboBox;
+    private DefaultTableModel tableModel;
+    private IncomeApplyDAO incomeApplyDAO;
+    Color color = new Color(0x615959);
+
+    public AdminIncomeApplyUI(String id) {
+        incomeApplyDAO = new IncomeApplyDAO();
+
+        // JFrame 설정
+        setTitle("입고 신청 내역 시스템_Admin");
+        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        setSize(900, 700);
+        setLayout(new BorderLayout()); // 기본 레이아웃 설정
+
+        setupUI(id);
+
+        // 초기 데이터 로드
+        loadProductData("전체", "");
+
+        // JFrame 표시
+        setLocationRelativeTo(null);
+        setVisible(true);
+    }
+
+    private void setupUI(String id) {
+        Font fontT  = new Font("맑은 고딕", Font.BOLD, 16);
+        Font fontC = new Font("맑은 고딕", Font.BOLD,12);
+        // Top Panel
+        JPanel topPanel = new JPanel(new BorderLayout());
+        topPanel.setPreferredSize(new Dimension(1200, 30));
+        JButton dropdownButton = new JButton("≡");
+        dropdownButton.setSize(30, 30);
+
+        // JPopupMenu 생성
+        JPopupMenu menu = new JPopupMenu();
+        JMenuItem logoutItem = new JMenuItem("로그아웃");
+        menu.add(logoutItem);
+        dropdownButton.addActionListener(e -> menu.show(dropdownButton, 0, dropdownButton.getHeight()));
+
+        JLabel welcomeLabel = new JLabel("< " + id + " > 님 환영합니다.     ", SwingConstants.RIGHT);
+        topPanel.add(welcomeLabel, BorderLayout.CENTER);
+        topPanel.setBackground(Color.GRAY);
+        topPanel.add(dropdownButton, BorderLayout.EAST);
+        dropdownButton.setBackground(Color.LIGHT_GRAY);
+        add(topPanel, BorderLayout.NORTH);
+
+        // Left Panel
+        JPanel leftPanel = new JPanel(new GridLayout(6, 1, 10, 10));
+        JLabel llabel = new JLabel("");
+        JButton invenUIButton = new JButton("재 고  현 황");
+        invenUIButton.setBackground(color);
+        invenUIButton.setForeground(Color.white);
+        invenUIButton.setFont(fontT);
+        JButton ioUIButton = new JButton("입출고 현황");
+        ioUIButton.setBackground(color);
+        ioUIButton.setForeground(Color.white);
+        ioUIButton.setFont(fontT);
+        JButton incomeButton = new JButton("입고신청 관리");
+        incomeButton.setBackground(color);
+        incomeButton.setForeground(Color.white);
+        incomeButton.setFont(fontT);
+        JButton ordButton = new JButton("주 문  관 리");
+        ordButton.setBackground(color);
+        ordButton.setForeground(Color.white);
+        ordButton.setFont(fontT);
+        JButton purordButton = new JButton("발 주  관 리");
+        purordButton.setBackground(color);
+        purordButton.setForeground(Color.white);
+        purordButton.setFont(fontT);
+
+        leftPanel.add(llabel);
+        leftPanel.add(invenUIButton);
+        leftPanel.add(ioUIButton);
+        leftPanel.add(incomeButton);
+        leftPanel.add(ordButton);
+        leftPanel.add(purordButton);
+        leftPanel.setPreferredSize(new Dimension(150, 600));
+        add(leftPanel, BorderLayout.WEST);
+
+        // Center Panel
+        JPanel centerPanel = new JPanel(new BorderLayout());
+        JPanel filterPanel = new JPanel(new BorderLayout()); // BorderLayout 사용
+
+        // 왼쪽에 위치할 버튼 패널
+        JPanel leftButtonPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        JButton allApplyButton = new JButton("전체 내역");
+        JButton yetApplyButton = new JButton("미승인 내역");
+
+        // 버튼 스타일 설정
+        allApplyButton.setFont(fontC);
+        allApplyButton.setBackground(color);
+        allApplyButton.setForeground(Color.WHITE);
+        yetApplyButton.setFont(fontC);
+        yetApplyButton.setBackground(color);
+        yetApplyButton.setForeground(Color.WHITE);
+        leftButtonPanel.add(allApplyButton);
+        leftButtonPanel.add(yetApplyButton);
+
+        // 오른쪽에 위치할 검색 패널
+        JPanel rightSearchPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        categoryComboBox = new JComboBox<>(new String[]{"전체", "상품 코드", "상품 이름", "주문 가격", "공급 가격", "재고 수량", "카테고리 코드", "카테고리명"});
+        JTextField searchField = new JTextField(15);
+        JButton searchButton = new JButton("검색");
+        rightSearchPanel.add(categoryComboBox);
+        rightSearchPanel.add(searchField);
+        rightSearchPanel.add(searchButton);
+
+        // 왼쪽과 오른쪽 패널을 필터 패널에 배치
+        filterPanel.add(leftButtonPanel, BorderLayout.WEST);
+        filterPanel.add(rightSearchPanel, BorderLayout.EAST);
+        centerPanel.add(filterPanel, BorderLayout.NORTH);
+
+
+        // 테이블 설정
+        tableModel = new DefaultTableModel(
+                new String[]{"신청 코드", "상품 코드", "상품명", "카테고리", "신청자 ID", "신청 시간", "승인 상태"}, 0) {
+            @Override
+            public Class<?> getColumnClass(int columnIndex) {
+                switch (columnIndex) {
+                    case 0: // 신청 ID
+                    case 1: // 상품 ID
+                        return Integer.class;
+                    case 5: // 신청 시간
+                        return LocalDateTime.class;
+                    default:
+                        return String.class;
+                }
+            }
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return false; // 모든 셀을 편집 불가능하게 설정
+            }
+        };
+        applicationTable = new JTable(tableModel);
+        JScrollPane tableScrollPane = new JScrollPane(applicationTable);
+        centerPanel.add(tableScrollPane, BorderLayout.CENTER);
+        add(centerPanel, BorderLayout.CENTER);
+
+        // Bottom Panel
+        JPanel bottomPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        JLabel blabel = new JLabel("");
+        JButton approveApplyButton = new JButton("신청 승인(발주)");
+        bottomPanel.add(blabel);
+        bottomPanel.add(approveApplyButton);
+        approveApplyButton.setFont(fontC);
+        add(bottomPanel, BorderLayout.SOUTH);
+
+        // 이벤트 리스너 추가
+        searchButton.addActionListener(e -> {
+            String selectedColumn = (String) categoryComboBox.getSelectedItem(); // 선택된 컬럼
+            String searchKeyword = searchField.getText(); // 검색어
+            loadProductData(selectedColumn, searchKeyword);
+        });
+
+        allApplyButton.addActionListener(e -> {
+            tableModel.setRowCount(0); // 기존 데이터 삭제
+            List<ProductIncomeApplyVO> applications = incomeApplyDAO.listIncomeApply(null, null);
+            for (ProductIncomeApplyVO application : applications) {
+                tableModel.addRow(new Object[]{
+                        IncomeApplyService.encondApplyId(application.getApplyId()),
+                        application.getProductId(),
+                        application.getProductName(),
+                        application.getCategoryName(),
+                        application.getUserId(),
+                        application.getApplyTime(),
+                        application.getApplyStatus()
+                });
+            }
+        });
+        yetApplyButton.addActionListener(e -> {
+            tableModel.setRowCount(0); // 기존 데이터 삭제
+            List<ProductIncomeApplyVO> applications = incomeApplyDAO.listPendingIncomeApplies();
+            for (ProductIncomeApplyVO application : applications) {
+                tableModel.addRow(new Object[]{
+                        IncomeApplyService.encondApplyId(application.getApplyId()),
+                        application.getProductId(),
+                        application.getProductName(),
+                        application.getCategoryName(),
+                        application.getUserId(),
+                        application.getApplyTime(),
+                        application.getApplyStatus()
+                });
+            }
+        });
+
+        ioUIButton.addActionListener(e -> JOptionPane.showMessageDialog(this, "입출고 관리 버튼 클릭됨"));
+        incomeButton.addActionListener(e -> {
+            new AdminIncomeApplyUI(id);  // 새로운 UI 열기
+            this.dispose();        // 현재 창 닫기
+        });
+        ordButton.addActionListener(e -> JOptionPane.showMessageDialog(this, "주문 관리 버튼 클릭됨"));
+        purordButton.addActionListener(e -> {
+            new ListSupplyUI(id);  // 새로운 UI 열기
+            this.dispose();        // 현재 창 닫기
+        });
+
+        approveApplyButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                supplySelectedRows();
+            }
+        });
+    }
+
+    public void loadProductData(String selectedColumn, String searchKeyword) {
+        tableModel.setRowCount(0); // 기존 데이터 삭제
+
+        List<ProductIncomeApplyVO> applications = incomeApplyDAO.listIncomeApply(selectedColumn, searchKeyword);
+
+        for (ProductIncomeApplyVO application : applications) {
+            tableModel.addRow(new Object[]{
+                    IncomeApplyService.encondApplyId(application.getApplyId()),
+                    application.getProductId(),
+                    application.getProductName(),
+                    application.getCategoryName(),
+                    application.getUserId(),
+                    application.getApplyTime(),
+                    application.getApplyStatus()
+            });
+        }
+    }
+
+    private void supplySelectedRows() {
+        int selectedRow = applicationTable.getSelectedRow();
+        if (selectedRow == -1) {
+            JOptionPane.showMessageDialog(this, "승인할 신청을 선택해주세요.");
+            return;
+        }
+
+        // 승인 상태 조건 확인 기능
+        String applyStatus = tableModel.getValueAt(selectedRow, 6).toString();
+        if (applyStatus.equals("completed")) {
+            JOptionPane.showMessageDialog(this, "이미 승인된 요청입니다.");
+            return;
+        }
+
+        // 선택된 행에서 상품 ID를 가져옵니다.
+        int productId = Integer.parseInt(tableModel.getValueAt(selectedRow, 1).toString()); // 상품 ID가 있는 열의 인덱스를 확인하세요.
+        String productName = tableModel.getValueAt(selectedRow, 2).toString(); // 상품 이름
+
+        // 사용자에게 발주 수량을 입력받습니다.
+        String input = JOptionPane.showInputDialog(this,
+                "상품명: " + productName + "\n발주 수량을 입력하세요:",
+                "발주 승인",
+                JOptionPane.QUESTION_MESSAGE);
+
+        if (input == null) {
+            // 사용자가 취소한 경우 아무 작업도 하지 않고 리턴
+            return;
+        }
+
+        if (input.trim().isEmpty()) {
+            JOptionPane.showMessageDialog(this, "수량을 입력해주세요.");
+            return;
+        }
+
+        try {
+            int supplyAmount = Integer.parseInt(input.trim());
+            if (supplyAmount <= 0) {
+                JOptionPane.showMessageDialog(this, "유효한 수량을 입력해주세요.");
+                return;
+            }
+
+            // SupplyVO 객체 생성 및 값 설정
+            SupplyVO supplyVO = new SupplyVO();
+            supplyVO.setProductId(productId);
+            supplyVO.setSupplyAmount(supplyAmount);
+
+            // DAO 메서드를 호출하여 발주를 등록합니다.
+            incomeApplyDAO.registerApply(supplyVO);
+
+            JOptionPane.showMessageDialog(this, "입고 신청이 성공적으로 승인되었습니다.");
+            loadProductData("전체", ""); // 테이블 데이터를 새로고침합니다.
+
+        } catch (NumberFormatException ex) {
+            JOptionPane.showMessageDialog(this, "유효한 숫자를 입력해주세요.");
+        } catch (SQLException ex) {
+            JOptionPane.showMessageDialog(this, "데이터베이스 오류: " + ex.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/ssginc/wms/supply/IncomeApplyDAO.java
+++ b/src/main/java/com/ssginc/wms/supply/IncomeApplyDAO.java
@@ -1,0 +1,148 @@
+package com.ssginc.wms.supply;
+
+import com.ssginc.wms.hikari.HikariCPDataSource;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class IncomeApplyDAO {
+
+    // 관리자 입고 신청 내역 메서드(전체)
+    public List<ProductIncomeApplyVO> listIncomeApply(String columnName, String searchKeyword) {
+        List<ProductIncomeApplyVO> incomeApplies = new ArrayList<>();
+        String query = """
+        SELECT 
+            ia.apply_id,
+            p.product_id,
+            p.product_name,
+            pc.category_name,
+            ia.user_id,
+            ia.apply_time,
+            ia.apply_status
+        FROM income_apply ia
+        JOIN product p ON ia.product_id = p.product_id
+        JOIN product_category pc ON p.category_id = pc.category_id
+    """;
+
+        // 기본 조건: user_id에 _가 포함되지 않은 행만 선택
+        String baseCondition = " WHERE ia.user_id NOT LIKE '%\\_%'";
+
+        // 검색 조건 추가
+        if (columnName != null && !columnName.equals("전체") && searchKeyword != null && !searchKeyword.isEmpty()) {
+            query += baseCondition + " AND " + columnName + " = ?";
+        } else {
+            query += baseCondition;
+        }
+
+        query += " ORDER BY ia.apply_time DESC";
+
+        try (Connection conn = HikariCPDataSource.getInstance().getDataSource().getConnection();
+             PreparedStatement stmt = conn.prepareStatement(query)) {
+
+            if (columnName != null && !columnName.equals("전체") && searchKeyword != null && !searchKeyword.isEmpty()) {
+                stmt.setString(1, searchKeyword);
+            }
+
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    ProductIncomeApplyVO incomeApply = new ProductIncomeApplyVO();
+                    incomeApply.setApplyId(rs.getInt("apply_id"));
+                    incomeApply.setProductId(rs.getInt("product_id"));
+                    incomeApply.setProductName(rs.getString("product_name"));
+                    incomeApply.setCategoryName(rs.getString("category_name"));
+                    incomeApply.setUserId(rs.getString("user_id"));
+                    incomeApply.setApplyTime(rs.getTimestamp("apply_time").toLocalDateTime());
+
+                    String status = rs.getString("apply_status");
+                    if (status != null) {
+                        incomeApply.setApplyStatus(ProductIncomeApplyVO.Process.valueOf(status.toLowerCase()));
+                    }
+
+                    incomeApplies.add(incomeApply);
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return incomeApplies;
+    }
+
+    // 관리자 입고 신청 내역 메서드(미승인)
+    public List<ProductIncomeApplyVO> listPendingIncomeApplies() {
+        List<ProductIncomeApplyVO> incomeApplies = new ArrayList<>();
+        String query = """
+        SELECT
+            ia.apply_id,
+            p.product_id,
+            p.product_name,
+            pc.category_name,
+            ia.user_id,
+            ia.apply_time,
+            ia.apply_status
+        FROM income_apply ia
+        JOIN product p ON ia.product_id = p.product_id
+        JOIN product_category pc ON p.category_id = pc.category_id
+        WHERE ia.user_id NOT LIKE '%\\_%' AND ia.apply_status = 'pending'
+        ORDER BY ia.apply_time DESC
+    """;
+
+        try (Connection conn = HikariCPDataSource.getInstance().getDataSource().getConnection();
+             PreparedStatement stmt = conn.prepareStatement(query);
+             ResultSet rs = stmt.executeQuery()) {
+
+            while (rs.next()) {
+                ProductIncomeApplyVO incomeApply = new ProductIncomeApplyVO();
+                incomeApply.setApplyId(rs.getInt("apply_id"));
+                incomeApply.setProductId(rs.getInt("product_id"));
+                incomeApply.setProductName(rs.getString("product_name"));
+                incomeApply.setCategoryName(rs.getString("category_name"));
+                incomeApply.setUserId(rs.getString("user_id"));
+                incomeApply.setApplyTime(rs.getTimestamp("apply_time").toLocalDateTime());
+                incomeApply.setApplyStatus(ProductIncomeApplyVO.Process.valueOf(rs.getString("apply_status").toLowerCase()));
+                incomeApplies.add(incomeApply);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return incomeApplies;
+    }
+
+    // 입고 신청에 대한 발주 등록 및 상태 업데이트 메서드
+    public void registerApply(SupplyVO supplyVO) throws SQLException {
+        String insertSupplySQL = "INSERT INTO Supply (supply_amount, product_id, supply_time) VALUES (?, ?, NOW())";
+        String updateProductSQL = "UPDATE PRODUCT SET product_amount = product_amount + ? WHERE product_id = ?";
+        String updateIncomeApplySQL = "UPDATE income_apply SET apply_status = 'completed' WHERE product_id = ?";
+
+        try (Connection conn = HikariCPDataSource.getInstance().getDataSource().getConnection()) {
+            conn.setAutoCommit(false); // 트랜잭션 시작
+
+            try (PreparedStatement pstmt1 = conn.prepareStatement(insertSupplySQL);
+                 PreparedStatement pstmt2 = conn.prepareStatement(updateProductSQL);
+                 PreparedStatement pstmt3 = conn.prepareStatement(updateIncomeApplySQL)) {
+
+                // SupplyVO 객체를 사용하여 PreparedStatement에 값 설정
+                pstmt1.setInt(1, supplyVO.getSupplyAmount());
+                pstmt1.setInt(2, supplyVO.getProductId());
+                pstmt1.executeUpdate();
+
+                // 상품 재고량 업데이트
+                pstmt2.setInt(1, supplyVO.getSupplyAmount());
+                pstmt2.setInt(2, supplyVO.getProductId());
+                pstmt2.executeUpdate();
+
+                // 입고 신청 상태 업데이트
+                pstmt3.setInt(1, supplyVO.getProductId());
+                pstmt3.executeUpdate();
+
+                conn.commit(); // 트랜잭션 커밋
+            } catch (SQLException e) {
+                conn.rollback(); // 오류 발생 시 롤백
+                throw e;
+            }
+        }
+    }
+}

--- a/src/main/java/com/ssginc/wms/supply/IncomeApplyService.java
+++ b/src/main/java/com/ssginc/wms/supply/IncomeApplyService.java
@@ -1,0 +1,32 @@
+
+package com.ssginc.wms.supply;
+
+public class IncomeApplyService {
+    // int --> String
+    public static String encondApplyId(int incomeApplyId) {
+        StringBuilder sTemp = new StringBuilder();
+        sTemp.append("IA");
+        String convertedId = String.valueOf(incomeApplyId);
+
+        for (int i = 0; i < 4 - convertedId.length(); i++) {
+            sTemp.append("0");
+        }
+        sTemp.append(convertedId);
+
+        return sTemp.toString();
+    }
+    // String --> int
+    public static int decodeApplyId(String incomeApplyId) {
+        // 앞에서 부터 0이 나오지 않는 시점을 찾음
+        // 주문 번호는 1부터 auto_increment 하므로 0이 아닌 문자가 포함됨
+        // 아닌 위치부터 끝까지 잘라서 int로 변환하여야 함.
+        for (int i = 0; i < incomeApplyId.length(); i++) {
+            char c = incomeApplyId.charAt(i);
+            //
+            if (Character.isDigit(c) && c > '0' && c <= '9') {
+                return Integer.parseInt(incomeApplyId.substring(i));
+            }
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/ssginc/wms/supply/ProductIncomeApplyVO.java
+++ b/src/main/java/com/ssginc/wms/supply/ProductIncomeApplyVO.java
@@ -1,0 +1,26 @@
+package com.ssginc.wms.supply;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+
+@Setter
+@Getter
+@ToString
+public class ProductIncomeApplyVO {
+    private int applyId;
+    private int productId;
+    private String productName;
+    private String categoryName;
+    private String userId;
+    private LocalDateTime applyTime;
+    private Process applyStatus;
+
+    public enum Process {
+        pending,
+        completed
+    }
+}


### PR DESCRIPTION
## 구현 내용
 - 관리자 입고 신청 내역에서 선택된 상품을 발주 등록
 - 입고 신청 내역을 '전체'와 '미승인'으로 나누어 확인 가능
 - 발주 등록에 성공할 경우 
   - 발주 테이블에 insert 
   - 상품 테이블의 재고량 update
   - 입고신청 테이블의 상태 update
 - 관리자 입고 신청 내역에서 다음과 같은 신청 현황을 확인 후 발주 등록
   - 신청 코드 
   - 상품 코드
   - 상품 이름
   - 카테고리
   - 신청자 ID
   - 신청 시간
   - 승인 상태

 - 관리자 발주 내역에 다음과 같은 내역을 추가
   - 발주 코드 
   - 상품 코드
   - 상품 이름
   - 카테고리
   - 발주 단가
   - 발주 수량
   - 총 주문 가격(추가 예정)
   - 발주일


## 주요 메서드
  - listIncomeApply(String, String): 발주할 상품을 선택하기 위한 전체 입고 신청 내역 반환 (+검색 가능)
  - listPendingIncomeApplies(): 발주할 상품을 선택하기 위한 미승인 입고 신청 내역 반환
  - registerApply(SupplyVO): 입고 신청에 대한 발주 등록 후 재고량 및 상태 업데이트


## 결과 UI
 - 입고 신청 전체 내역
![image](https://github.com/user-attachments/assets/d42635a7-76fc-4954-b782-881da52c41a1)

 - 입고 신청 미승인 내역
![image](https://github.com/user-attachments/assets/dbade37f-84dc-4eb9-bdaa-0509457d44a4)

 - 발주 수량 입력
![image](https://github.com/user-attachments/assets/44a6083c-4908-4da2-89ec-b3d08f254397)

 - 발주 등록 성공
![image](https://github.com/user-attachments/assets/036dd473-5821-417a-9c28-760d20732965)

 - 발주 내역에 insert
![image](https://github.com/user-attachments/assets/df7a6aeb-3596-47bc-b3d2-41d6b31753b1)

 - 재고 현황의 재고량 update(Novel의 기존 재고량: 1500)
![image](https://github.com/user-attachments/assets/4d17970f-04a8-41a1-93d6-84d8df3f4cc1)

 - 입고 신청 내역의 상태 update(기존 상태: pending)
![image](https://github.com/user-attachments/assets/db066627-f6fe-4c52-93f1-0b53001742de)

 - 발주 실패 (이미 승인된 신청에 대한 승인)
![image](https://github.com/user-attachments/assets/9a277355-a35f-405d-8950-325f430e21db)

 - 발주 실패 (상품 선택 없이 발주 등록)
![image](https://github.com/user-attachments/assets/e375de05-904b-4af7-b9c7-dad13612987b)

 - 발주 실패 (잘못된 수량 입력)
![image](https://github.com/user-attachments/assets/ae251f7c-22dd-4d9e-84d0-9463d23504ee)
