### PR TITLE
feat: 재고 부족 시 입고 신청 및 데이터 삽입 기능 추가

### DIFF
--- a/src/main/java/com/ssginc/wms/incomeApply/IncomeApplyDAO.java
+++ b/src/main/java/com/ssginc/wms/incomeApply/IncomeApplyDAO.java
@@ -4,6 +4,7 @@ import com.ssginc.wms.hikari.HikariCPDataSource;
 
 import javax.sql.DataSource;
 import java.sql.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -149,5 +150,25 @@ public class IncomeApplyDAO {
             System.err.println("DB 오류: " + e.getMessage());
         }
         return incomeApplies;
+    }
+
+    // 입고 신청 데이터 삽입 메서드
+    public void insertIncomeApply(IncomeApplyVO incomeApplyVO) {
+        String sql = "INSERT INTO income_apply (product_id, user_id, apply_time) " +
+                "VALUES (?, ?, ?)";
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+            pstmt.setInt(1, incomeApplyVO.getProductId());
+            pstmt.setString(2, incomeApplyVO.getUserId());
+            pstmt.setTimestamp(3, Timestamp.valueOf(incomeApplyVO.getApplyTime()));
+
+            int rows = pstmt.executeUpdate();
+            if (rows > 0) {
+                System.out.println("입고 신청 데이터가 성공적으로 삽입되었습니다.");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/main/java/com/ssginc/wms/incomeApply/IncomeApplyVO.java
+++ b/src/main/java/com/ssginc/wms/incomeApply/IncomeApplyVO.java
@@ -1,0 +1,23 @@
+package com.ssginc.wms.incomeApply;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@ToString
+public class IncomeApplyVO {
+    private int applyId;
+    private int productId;
+    private String userId;
+    private LocalDateTime applyTime;
+    private Process applyStatus;
+
+    public enum Process {
+        pending,
+        completed
+    }
+}

--- a/src/main/java/com/ssginc/wms/product/UserProductUI.java
+++ b/src/main/java/com/ssginc/wms/product/UserProductUI.java
@@ -1,6 +1,8 @@
 package com.ssginc.wms.product;
 
 import com.ssginc.wms.frame.CustomerFrame;
+import com.ssginc.wms.incomeApply.IncomeApplyDAO;
+import com.ssginc.wms.incomeApply.IncomeApplyVO;
 import com.ssginc.wms.ord.OrdDAO;
 import com.ssginc.wms.ord.OrdVO;
 
@@ -102,6 +104,18 @@ public class UserProductUI extends CustomerFrame {
                                 else {
                                     JOptionPane.showMessageDialog(this, "재고량이 부족하여 입고신청을 진행합니다.");
                                     // 입고 신청 내역 insert 작성 필요
+                                    IncomeApplyDAO incomeApplyDAO = new IncomeApplyDAO();
+                                    IncomeApplyVO incomeApplyVO = new IncomeApplyVO();
+
+                                    incomeApplyVO.setProductId(productId); // 선택된 상품 ID
+                                    incomeApplyVO.setUserId("user1");
+                                    incomeApplyVO.setApplyTime(LocalDateTime.now()); // 현재 시간
+
+                                    // 입고 신청 데이터를 삽입
+                                    incomeApplyDAO.insertIncomeApply(incomeApplyVO);
+
+                                    JOptionPane.showMessageDialog(this, "입고 신청이 완료되었습니다.");
+                                    break;
                                 }
                                 break;
                             }


### PR DESCRIPTION
## PR 설명:
이 PR에서는 재고가 부족한 경우 자동으로 입고 신청을 진행하는 기능을 추가했습니다. 주요 변경 사항은 다음과 같습니다:

**1. 재고 부족 처리 및 입고 신청 로직 추가:**

- 사용자가 주문하려는 수량이 재고보다 많을 경우, IncomeApplyDAO를 통해 입고 신청 내역을 자동으로 삽입합니다.

- 입고 신청 데이터는 IncomeApplyVO 객체를 통해 생성되고, insertIncomeApply 메서드를 사용해 income_apply 테이블에 저장됩니다.

- 입고 신청을 진행할 때, 사용자에게 "재고량이 부족하여 입고신청을 진행합니다."와 "입고 신청이 완료되었습니다."라는 메시지가 JOptionPane을 통해 표시됩니다.

**2. 입고 신청 내역 데이터 삽입:**

- IncomeApplyVO 객체에는 productId, userId, **applyTime**이 설정됩니다.

- userId는 현재 하드코딩된 "user1"로 설정되어 있으며, 추후 사용자 인증 시스템과 연동될 수 있습니다.

- 현재 시간(LocalDateTime.now())을 applyTime으로 설정하여 입고 신청 시간을 기록합니다.

**3.IncomeApplyDAO 클래스에 insertIncomeApply 메서드 추가:**

- insertIncomeApply 메서드를 통해 income_apply 테이블에 상품 ID, 사용자 ID, 신청 시간을 삽입합니다.

- 데이터 삽입 성공 시 콘솔 로그로 확인할 수 있도록 처리하였습니다.

## 주요 변경 파일:
**1.UserProductUI.java:**
- 재고 부족 시 입고 신청 처리 로직 추가.

- IncomeApplyDAO와 IncomeApplyVO를 사용하여 입고 신청 데이터를 DB에 삽입.

**2.IncomeApplyDAO.java:**
- insertIncomeApply 메서드 구현: 입고 신청 데이터를 income_apply 테이블에 삽입.

## 테스트:

- 재고가 부족할 경우 입고 신청 내역이 정상적으로 income_apply 테이블에 삽입됨을 확인했습니다.

- 사용자에게 입고 신청 진행 상황을 알리는 메시지가 정상적으로 표시되는지 확인했습니다.
