### PR TITLE
fix: 상품 삭제 기능 구현 코드 수정.

### DIFF
--- a/src/main/java/com/ssginc/wms/product/ProductDAO.java
+++ b/src/main/java/com/ssginc/wms/product/ProductDAO.java
@@ -79,11 +79,12 @@ public class ProductDAO {
     // 상품 목록 조회
     public List<ProductVO> getProducts(String columnName, String searchKeyword) {
         List<ProductVO> productList = new ArrayList<>();
-        String query = "SELECT * FROM product";
+        String query = "SELECT * FROM product where ";
 
         if (columnName != null && searchKeyword != null && !searchKeyword.isEmpty()) {
-            query += " WHERE " + columnName + " = ?";
+            query += " WHERE " + columnName + " = ? and ";
         }
+        query += "product_status = 'present'";
 
         try (Connection conn = dataSource.getConnection();
              PreparedStatement stmt = conn.prepareStatement(query)) {
@@ -153,7 +154,7 @@ public class ProductDAO {
 
     // 상품 삭제
     public boolean deleteProduct(int productId) {
-        String deleteQuery = "DELETE FROM product WHERE product_id = ?";
+        String deleteQuery = "UPDATE product SET product_status = 'deleted' WHERE product_id = ?";
         try (Connection conn = dataSource.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(deleteQuery)) {
             pstmt.setInt(1, productId);
@@ -165,7 +166,7 @@ public class ProductDAO {
     }
 
     public ProductVO getProductById(int productId) {
-        String query = "SELECT * FROM product WHERE product_id = ?";
+        String query = "SELECT * FROM product WHERE product_id = ? and product_status = 'present'";
         try (Connection conn = dataSource.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(query)) {
 


### PR DESCRIPTION
## 문제 설명

![ERD 최종](https://github.com/user-attachments/assets/3e908df8-96cb-4f4a-a00f-3938be52f710)

- 문제 설명: delete문을 이용해 상품을 삭제하면 _product table_ 에서 해당 _"product_id"_ 의 상품이 삭제되어 _"product_id"_ 를 FK로 갖는 _"ord" table, "supply" table, "income_apply" table_ 때문에 삭제 기능이 작동되지 않는다.(FK로 갖는 테이블의 데이터 먼저 삭제 후 PK 테이블 삭제 가능.) 또한 삭제되더라도 각각의 테이블에 연동되어 있는 "주문 내역", "입고 신청 내역"에서 삭제된 상품의 데이터가 출력되지 않는다.

- 문제 해결: _"product"_ 테이블에 _"product_status"_ column을 추가해 상품의 상태를 "present"와 "deleted"로 구분해준다. query문에 _"where product_status = 'present'"_ 를 추가해주어 deleted 상태가 아닌 상품들만 보여준다.
   
   
## 수정 내용
 - 상품 삭제 기능 구현 코드 수정
   - 기존 코드: `"DELETE FROM product where product = id?";`
   - 신규 코드: `"UPDATE product SET product_status = 'deleted' WHERE product_id = ?";`

